### PR TITLE
Update demo script to pass arguments to qtap execution

### DIFF
--- a/demo
+++ b/demo
@@ -153,7 +153,7 @@ run() {
     if [ "$(id -u)" != "0" ]; then
         action "please run qtap as root:
 
-    $(bold "sudo $(pwd)/qtap")
+    $(bold "sudo $(pwd)/qtap [args...]")
 
 "
         exit 0
@@ -161,10 +161,10 @@ run() {
 
     action "running Qtap demo"
     echo ""
-    ./qtap
+    ./qtap "$@"
 }
 
 banner
 setup
 install
-run
+run "$@"


### PR DESCRIPTION
- Accept command line arguments in the demo script
- Pass all arguments through to qtap when running
- Update help text to show arguments can be passed when running as non-root