### PR TITLE
adds qcontrol download script + drops demo

### DIFF
--- a/qcontrol/README.md
+++ b/qcontrol/README.md
@@ -1,6 +1,6 @@
-# Qcontrol Installer
+# Qcontrol Installer and Downloader
 
-This repo hosts an installation script for Qcontrol.
+This repo hosts installation and download scripts for Qcontrol.
 
 ```sh
 # installs into /usr/local/bin/qcontrol
@@ -9,15 +9,16 @@ curl -s https://get.qpoint.io/qcontrol/install | sh
 
 ```sh
 # downloads to current directory to be run as ./qcontrol
-curl -s https://get.qpoint.io/qcontrol/demo | sh
+curl -s https://get.qpoint.io/qcontrol/download | sh
 ```
 
-#### Installing a specific version
+#### Installing or downloading a specific version
 
 You can specify a version via the `VERSION` env var:
 
 ```sh
 curl -s https://get.qpoint.io/qcontrol/install | VERSION=v0.9.10 sh
+curl -s https://get.qpoint.io/qcontrol/download | VERSION=v0.9.10 sh
 ```
 
 ## What's Next?

--- a/qcontrol/download
+++ b/qcontrol/download
@@ -19,9 +19,9 @@
 #          ┃┃ ┃┃ ┃┃ ┃ ┃┃ ┃
 #          ┗┣ ┣┛ ┗┛ ┻ ┛┗ ┻
 #
-# This is a demo script for Qcontrol (https://qpoint.io). Please run:
+# This is a download script for Qcontrol (https://qpoint.io). Please run:
 #
-#     curl -s https://get.qpoint.io/qcontrol/demo | sh
+#     curl -s https://get.qpoint.io/qcontrol/download | sh
 #
 #
 
@@ -132,7 +132,7 @@ banner() {
     echo ""
 }
 
-install() {
+download() {
     BINARY="./qcontrol"
 
     action "downloading Qcontrol [$(bold "${VERSION}")]"
@@ -166,6 +166,6 @@ run() {
 
 banner
 setup
-install
+download
 
 run "--help"


### PR DESCRIPTION
- Renames the Qcontrol demo download endpoint to `/qcontrol/download`
- Updates Qcontrol script instructions and README examples to describe downloading
- Drops the legacy `/qcontrol/demo` endpoint per request