### PR TITLE
add qcontrol install scopes

### DIFF
--- a/qcontrol/README.md
+++ b/qcontrol/README.md
@@ -3,8 +3,13 @@
 This repo hosts installation and download scripts for Qcontrol.
 
 ```sh
-# installs into /usr/local/bin/qcontrol
+# installs into $HOME/.local/bin/qcontrol
 curl -s https://get.qpoint.io/qcontrol/install | sh
+```
+
+```sh
+# installs into /usr/local/bin/qcontrol
+curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system
 ```
 
 ```sh
@@ -18,6 +23,7 @@ You can specify a version via the `VERSION` env var:
 
 ```sh
 curl -s https://get.qpoint.io/qcontrol/install | VERSION=v0.9.10 sh
+curl -s https://get.qpoint.io/qcontrol/install | sudo VERSION=v0.9.10 sh -s -- system
 curl -s https://get.qpoint.io/qcontrol/download | VERSION=v0.9.10 sh
 ```
 

--- a/qcontrol/install
+++ b/qcontrol/install
@@ -84,18 +84,14 @@ parse_args() {
 }
 
 resolve_install_path() {
-    if [ "$SCOPE" = "user" ]; then
-        INSTALL_PATH="$HOME/.local/bin/qcontrol"
-    else
-        INSTALL_PATH="/usr/local/bin/qcontrol"
-    fi
+    INSTALL_PATH="$(install_dir)/qcontrol"
 }
 
 install_dir() {
     if [ "$SCOPE" = "user" ]; then
         printf '%s' "$HOME/.local/bin"
     else
-        printf '%s' "/usr/local/bin"
+        printf '%s' "${QCONTROL_TEST_SYSTEM_BIN:-/usr/local/bin}"
     fi
 }
 

--- a/qcontrol/install
+++ b/qcontrol/install
@@ -34,6 +34,7 @@ VERSION=${VERSION:-latest}
 OS=
 ARCH=
 INSTALL_PATH=
+SCOPE=
 
 RED=
 GREEN=
@@ -76,6 +77,10 @@ success() {
 
 download_url() {
     printf "https://downloads.qpoint.io/qcontrol/qcontrol-%s-%s-%s.tgz" "$VERSION" "$OS" "$ARCH"
+}
+
+parse_args() {
+    SCOPE=${1:-user}
 }
 
 setup() {
@@ -148,29 +153,16 @@ install() {
     tar -xzf "${dir}/qcontrol.tgz" -C "$dir"
     chmod +x "${dir}/qcontrol"
 
-    INSTALL_PATH=""
-
-    # try /usr/local/bin first
-    if mv "${dir}/qcontrol" /usr/local/bin/qcontrol 2>/dev/null; then
-        INSTALL_PATH="/usr/local/bin/qcontrol"
-    # try current directory if /usr/local/bin failed
-    elif [ ! -e "./qcontrol" ] && mv "${dir}/qcontrol" "./qcontrol" 2>/dev/null; then
-        INSTALL_PATH="./qcontrol"
-    # fall back to /tmp
+    if [ "$SCOPE" = "user" ]; then
+        INSTALL_PATH="$HOME/.local/bin/qcontrol"
     else
-        mv "${dir}/qcontrol" /tmp/qcontrol
-        INSTALL_PATH="/tmp/qcontrol"
+        INSTALL_PATH="/usr/local/bin/qcontrol"
     fi
+
+    mv "${dir}/qcontrol" "$INSTALL_PATH"
 
     success "successfully installed $(bold "$("${INSTALL_PATH}" --version)") at $(bold "${INSTALL_PATH}")"
     printf '\n'
-
-    if [ "${INSTALL_PATH}" != "/usr/local/bin/qcontrol" ]; then
-        error "insufficient permissions, please move the binary manually:"
-        printf '\n'
-        printf "    sudo mv %s /usr/local/bin/\n" "${INSTALL_PATH}"
-        printf '\n'
-    fi
 }
 
 usage_instructions() {
@@ -180,9 +172,7 @@ usage_instructions() {
 }
 
 banner
+parse_args "$@"
 setup
 install
-
-if [ "${INSTALL_PATH}" = "/usr/local/bin/qcontrol" ]; then
-    usage_instructions
-fi
+usage_instructions

--- a/qcontrol/install
+++ b/qcontrol/install
@@ -23,6 +23,10 @@
 #
 #     curl -s https://get.qpoint.io/qcontrol/install | sh
 #
+# For a system-wide installation, run:
+#
+#     curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system
+#
 #
 
 set -eu
@@ -80,7 +84,29 @@ download_url() {
 }
 
 parse_args() {
+    if [ "$#" -gt 1 ]; then
+        usage_error "too many arguments"
+    fi
+
     SCOPE=${1:-user}
+
+    case "$SCOPE" in
+    user | system)
+        ;;
+    *)
+        usage_error "unsupported install scope $(bold "$SCOPE")"
+        ;;
+    esac
+}
+
+usage_error() {
+    error "$*"
+    printf >&2 '\n'
+    printf >&2 'usage:\n\n'
+    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sh\n'
+    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system\n\n'
+    printf >&2 'accepted scopes: user, system\n'
+    exit 1
 }
 
 resolve_install_path() {

--- a/qcontrol/install
+++ b/qcontrol/install
@@ -83,6 +83,42 @@ parse_args() {
     SCOPE=${1:-user}
 }
 
+resolve_install_path() {
+    if [ "$SCOPE" = "user" ]; then
+        INSTALL_PATH="$HOME/.local/bin/qcontrol"
+    else
+        INSTALL_PATH="/usr/local/bin/qcontrol"
+    fi
+}
+
+install_dir() {
+    if [ "$SCOPE" = "user" ]; then
+        printf '%s' "$HOME/.local/bin"
+    else
+        printf '%s' "/usr/local/bin"
+    fi
+}
+
+install_target_error() {
+    error "$*"
+    printf >&2 '\n'
+    printf >&2 'run the system install with sudo:\n\n'
+    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system\n\n'
+    exit 1
+}
+
+check_install_target() {
+    dir=$(install_dir)
+
+    if [ ! -d "$dir" ]; then
+        install_target_error "install directory $(bold "$dir") does not exist"
+    fi
+
+    if [ ! -w "$dir" ]; then
+        install_target_error "install directory $(bold "$dir") is not writable"
+    fi
+}
+
 setup() {
     case "$(uname -sr)" in
     Linux*)
@@ -142,6 +178,9 @@ banner() {
 install() {
     action "installing Qcontrol [$(bold "${VERSION}")]"
 
+    resolve_install_path
+    check_install_target
+
     if ! dir=$(mktemp -d); then
         fatal "failed to create temporary directory"
     fi
@@ -152,12 +191,6 @@ install() {
     curl -fsSL "$(download_url)" >"${dir}/qcontrol.tgz"
     tar -xzf "${dir}/qcontrol.tgz" -C "$dir"
     chmod +x "${dir}/qcontrol"
-
-    if [ "$SCOPE" = "user" ]; then
-        INSTALL_PATH="$HOME/.local/bin/qcontrol"
-    else
-        INSTALL_PATH="/usr/local/bin/qcontrol"
-    fi
 
     mv "${dir}/qcontrol" "$INSTALL_PATH"
 

--- a/tests/qcontrol-install-test.sh
+++ b/tests/qcontrol-install-test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env sh
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SCRIPT="$ROOT/qcontrol/install"
+
+fail() {
+    printf 'not ok - %s\n' "$*" >&2
+    return 1
+}
+
+assert_contains() {
+    haystack=$1
+    needle=$2
+
+    case "$haystack" in
+    *"$needle"*) ;;
+    *) fail "expected output to contain: $needle" ;;
+    esac
+}
+
+make_fake_tools() {
+    fakebin=$1
+
+    cat >"$fakebin/curl" <<'SH'
+#!/usr/bin/env sh
+
+set -eu
+
+: "${QCONTROL_TEST_MARKER:?}"
+touch "$QCONTROL_TEST_MARKER/curl-called"
+printf 'fake archive'
+SH
+    chmod +x "$fakebin/curl"
+
+    cat >"$fakebin/tar" <<'SH'
+#!/usr/bin/env sh
+
+set -eu
+
+out=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    -C)
+        shift
+        out=$1
+        ;;
+    esac
+    shift || true
+done
+
+if [ -z "$out" ]; then
+    printf 'missing output directory\n' >&2
+    exit 1
+fi
+
+cat >"$out/qcontrol" <<'QCONTROL'
+#!/usr/bin/env sh
+
+case "${1:-}" in
+--version)
+    printf 'qcontrol test version\n'
+    ;;
+--help)
+    printf 'qcontrol help\n'
+    ;;
+*)
+    printf 'qcontrol args: %s\n' "$*"
+    ;;
+esac
+QCONTROL
+chmod +x "$out/qcontrol"
+SH
+    chmod +x "$fakebin/tar"
+}
+
+test_default_scope_installs_to_user_bin() {
+    sandbox=$(mktemp -d)
+    trap 'rm -rf "$sandbox"' EXIT INT
+
+    home="$sandbox/home"
+    fakebin="$sandbox/bin"
+    workdir="$sandbox/work"
+    output_file="$sandbox/output"
+
+    mkdir -p "$home/.local/bin" "$fakebin" "$workdir"
+    make_fake_tools "$fakebin"
+
+    if ! (
+        cd "$workdir"
+        QCONTROL_TEST_MARKER="$sandbox" HOME="$home" PATH="$fakebin:$PATH" sh "$SCRIPT" >"$output_file" 2>&1
+    ); then
+        cat "$output_file" >&2
+        fail 'install command failed'
+    fi
+
+    output=$(cat "$output_file")
+
+    [ -x "$home/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
+    [ ! -e "$workdir/qcontrol" ] || fail 'expected no current-directory fallback'
+    assert_contains "$output" 'successfully installed qcontrol test version at'
+    assert_contains "$output" "$home/.local/bin/qcontrol"
+    assert_contains "$output" 'qcontrol help'
+}
+
+test_explicit_user_scope_installs_to_user_bin() {
+    sandbox=$(mktemp -d)
+    trap 'rm -rf "$sandbox"' EXIT INT
+
+    home="$sandbox/home"
+    fakebin="$sandbox/bin"
+    workdir="$sandbox/work"
+    output_file="$sandbox/output"
+
+    mkdir -p "$home/.local/bin" "$fakebin" "$workdir"
+    make_fake_tools "$fakebin"
+
+    if ! (
+        cd "$workdir"
+        QCONTROL_TEST_MARKER="$sandbox" HOME="$home" PATH="$fakebin:$PATH" sh "$SCRIPT" user >"$output_file" 2>&1
+    ); then
+        cat "$output_file" >&2
+        fail 'install command failed'
+    fi
+
+    output=$(cat "$output_file")
+
+    [ -x "$home/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
+    [ ! -e "$workdir/qcontrol" ] || fail 'expected no current-directory fallback'
+    assert_contains "$output" 'successfully installed qcontrol test version at'
+    assert_contains "$output" "$home/.local/bin/qcontrol"
+    assert_contains "$output" 'qcontrol help'
+}
+
+test_default_scope_installs_to_user_bin
+printf 'ok - default scope installs to user bin\n'
+test_explicit_user_scope_installs_to_user_bin
+printf 'ok - explicit user scope installs to user bin\n'

--- a/tests/qcontrol-install-test.sh
+++ b/tests/qcontrol-install-test.sh
@@ -37,6 +37,7 @@ set -eu
 
 : "${QCONTROL_TEST_MARKER:?}"
 touch "$QCONTROL_TEST_MARKER/curl-called"
+printf '%s\n' "$*" >"$QCONTROL_TEST_MARKER/curl-args"
 printf 'fake archive'
 SH
     chmod +x "$fakebin/curl"
@@ -237,6 +238,62 @@ test_missing_system_bin_fails_before_download() {
     teardown_test
 }
 
+test_invalid_scope_fails_before_download() {
+    setup_test
+    mkdir -p "$TEST_HOME/.local/bin" "$TEST_SYSTEM_BIN"
+
+    if run_install banana; then
+        fail 'expected install command to fail'
+    fi
+
+    output=$(cat "$TEST_OUTPUT")
+
+    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
+    assert_not_exists "$TEST_HOME/.local/bin/qcontrol" 'expected no user install'
+    assert_not_exists "$TEST_SYSTEM_BIN/qcontrol" 'expected no system install'
+    assert_contains "$output" 'accepted scopes: user, system'
+
+    teardown_test
+}
+
+test_extra_argument_fails_before_download() {
+    setup_test
+    mkdir -p "$TEST_HOME/.local/bin" "$TEST_SYSTEM_BIN"
+
+    if run_install user extra; then
+        fail 'expected install command to fail'
+    fi
+
+    output=$(cat "$TEST_OUTPUT")
+
+    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
+    assert_not_exists "$TEST_HOME/.local/bin/qcontrol" 'expected no user install'
+    assert_not_exists "$TEST_SYSTEM_BIN/qcontrol" 'expected no system install'
+    assert_contains "$output" 'accepted scopes: user, system'
+
+    teardown_test
+}
+
+test_version_env_is_used_in_download_url() {
+    setup_test
+    mkdir -p "$TEST_HOME/.local/bin"
+
+    VERSION=v0.9.10
+    export VERSION
+    if ! run_install; then
+        unset VERSION
+        cat "$TEST_OUTPUT" >&2
+        fail 'install command failed'
+    fi
+    unset VERSION
+
+    curl_args=$(cat "$TEST_SANDBOX/curl-args")
+
+    assert_contains "$curl_args" 'qcontrol-v0.9.10-'
+
+    teardown_test
+}
+
 test_default_scope_installs_to_user_bin
 printf 'ok - default scope installs to user bin\n'
 test_explicit_user_scope_installs_to_user_bin
@@ -249,3 +306,9 @@ test_system_scope_installs_to_system_bin
 printf 'ok - system scope installs to system bin\n'
 test_missing_system_bin_fails_before_download
 printf 'ok - missing system bin fails before download\n'
+test_invalid_scope_fails_before_download
+printf 'ok - invalid scope fails before download\n'
+test_extra_argument_fails_before_download
+printf 'ok - extra argument fails before download\n'
+test_version_env_is_used_in_download_url
+printf 'ok - version env is used in download url\n'

--- a/tests/qcontrol-install-test.sh
+++ b/tests/qcontrol-install-test.sh
@@ -80,6 +80,20 @@ QCONTROL
 chmod +x "$out/qcontrol"
 SH
     chmod +x "$fakebin/tar"
+
+    cat >"$fakebin/mv" <<'SH'
+#!/usr/bin/env sh
+
+set -eu
+
+if [ "${2:-}" = "/usr/local/bin/qcontrol" ]; then
+    printf 'refusing to write to real /usr/local/bin/qcontrol in tests\n' >&2
+    exit 1
+fi
+
+/bin/mv "$@"
+SH
+    chmod +x "$fakebin/mv"
 }
 
 setup_test() {
@@ -88,6 +102,7 @@ setup_test() {
 
     TEST_HOME="$TEST_SANDBOX/home"
     TEST_FAKEBIN="$TEST_SANDBOX/bin"
+    TEST_SYSTEM_BIN="$TEST_SANDBOX/system-bin"
     TEST_WORKDIR="$TEST_SANDBOX/work"
     TEST_OUTPUT="$TEST_SANDBOX/output"
 
@@ -102,7 +117,7 @@ teardown_test() {
 run_install() {
     (
         cd "$TEST_WORKDIR"
-        QCONTROL_TEST_MARKER="$TEST_SANDBOX" HOME="$TEST_HOME" PATH="$TEST_FAKEBIN:$PATH" sh "$SCRIPT" "$@" >"$TEST_OUTPUT" 2>&1
+        QCONTROL_TEST_MARKER="$TEST_SANDBOX" QCONTROL_TEST_SYSTEM_BIN="$TEST_SYSTEM_BIN" HOME="$TEST_HOME" PATH="$TEST_FAKEBIN:$PATH" sh "$SCRIPT" "$@" >"$TEST_OUTPUT" 2>&1
     )
 }
 
@@ -185,6 +200,43 @@ test_unwritable_user_bin_fails_before_download() {
     teardown_test
 }
 
+test_system_scope_installs_to_system_bin() {
+    setup_test
+    mkdir -p "$TEST_SYSTEM_BIN"
+
+    if ! run_install system; then
+        cat "$TEST_OUTPUT" >&2
+        fail 'install command failed'
+    fi
+
+    output=$(cat "$TEST_OUTPUT")
+
+    [ -x "$TEST_SYSTEM_BIN/qcontrol" ] || fail 'expected qcontrol in system bin'
+    assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
+    assert_contains "$output" 'successfully installed qcontrol test version at'
+    assert_contains "$output" "$TEST_SYSTEM_BIN/qcontrol"
+    assert_contains "$output" 'qcontrol help'
+
+    teardown_test
+}
+
+test_missing_system_bin_fails_before_download() {
+    setup_test
+
+    if run_install system; then
+        fail 'expected install command to fail'
+    fi
+
+    output=$(cat "$TEST_OUTPUT")
+
+    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
+    assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
+    assert_contains "$output" "$TEST_SYSTEM_BIN"
+    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system'
+
+    teardown_test
+}
+
 test_default_scope_installs_to_user_bin
 printf 'ok - default scope installs to user bin\n'
 test_explicit_user_scope_installs_to_user_bin
@@ -193,3 +245,7 @@ test_missing_user_bin_fails_before_download
 printf 'ok - missing user bin fails before download\n'
 test_unwritable_user_bin_fails_before_download
 printf 'ok - unwritable user bin fails before download\n'
+test_system_scope_installs_to_system_bin
+printf 'ok - system scope installs to system bin\n'
+test_missing_system_bin_fails_before_download
+printf 'ok - missing system bin fails before download\n'

--- a/tests/qcontrol-install-test.sh
+++ b/tests/qcontrol-install-test.sh
@@ -20,6 +20,13 @@ assert_contains() {
     esac
 }
 
+assert_not_exists() {
+    path=$1
+    message=$2
+
+    [ ! -e "$path" ] || fail "$message"
+}
+
 make_fake_tools() {
     fakebin=$1
 
@@ -75,65 +82,114 @@ SH
     chmod +x "$fakebin/tar"
 }
 
+setup_test() {
+    TEST_SANDBOX=$(mktemp -d)
+    trap 'rm -rf "$TEST_SANDBOX"' EXIT INT
+
+    TEST_HOME="$TEST_SANDBOX/home"
+    TEST_FAKEBIN="$TEST_SANDBOX/bin"
+    TEST_WORKDIR="$TEST_SANDBOX/work"
+    TEST_OUTPUT="$TEST_SANDBOX/output"
+
+    mkdir -p "$TEST_HOME" "$TEST_FAKEBIN" "$TEST_WORKDIR"
+    make_fake_tools "$TEST_FAKEBIN"
+}
+
+teardown_test() {
+    rm -rf "$TEST_SANDBOX"
+}
+
+run_install() {
+    (
+        cd "$TEST_WORKDIR"
+        QCONTROL_TEST_MARKER="$TEST_SANDBOX" HOME="$TEST_HOME" PATH="$TEST_FAKEBIN:$PATH" sh "$SCRIPT" "$@" >"$TEST_OUTPUT" 2>&1
+    )
+}
+
 test_default_scope_installs_to_user_bin() {
-    sandbox=$(mktemp -d)
-    trap 'rm -rf "$sandbox"' EXIT INT
+    setup_test
+    mkdir -p "$TEST_HOME/.local/bin"
 
-    home="$sandbox/home"
-    fakebin="$sandbox/bin"
-    workdir="$sandbox/work"
-    output_file="$sandbox/output"
-
-    mkdir -p "$home/.local/bin" "$fakebin" "$workdir"
-    make_fake_tools "$fakebin"
-
-    if ! (
-        cd "$workdir"
-        QCONTROL_TEST_MARKER="$sandbox" HOME="$home" PATH="$fakebin:$PATH" sh "$SCRIPT" >"$output_file" 2>&1
-    ); then
-        cat "$output_file" >&2
+    if ! run_install; then
+        cat "$TEST_OUTPUT" >&2
         fail 'install command failed'
     fi
 
-    output=$(cat "$output_file")
+    output=$(cat "$TEST_OUTPUT")
 
-    [ -x "$home/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
-    [ ! -e "$workdir/qcontrol" ] || fail 'expected no current-directory fallback'
+    [ -x "$TEST_HOME/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
+    [ ! -e "$TEST_WORKDIR/qcontrol" ] || fail 'expected no current-directory fallback'
     assert_contains "$output" 'successfully installed qcontrol test version at'
-    assert_contains "$output" "$home/.local/bin/qcontrol"
+    assert_contains "$output" "$TEST_HOME/.local/bin/qcontrol"
     assert_contains "$output" 'qcontrol help'
+
+    teardown_test
 }
 
 test_explicit_user_scope_installs_to_user_bin() {
-    sandbox=$(mktemp -d)
-    trap 'rm -rf "$sandbox"' EXIT INT
+    setup_test
+    mkdir -p "$TEST_HOME/.local/bin"
 
-    home="$sandbox/home"
-    fakebin="$sandbox/bin"
-    workdir="$sandbox/work"
-    output_file="$sandbox/output"
-
-    mkdir -p "$home/.local/bin" "$fakebin" "$workdir"
-    make_fake_tools "$fakebin"
-
-    if ! (
-        cd "$workdir"
-        QCONTROL_TEST_MARKER="$sandbox" HOME="$home" PATH="$fakebin:$PATH" sh "$SCRIPT" user >"$output_file" 2>&1
-    ); then
-        cat "$output_file" >&2
+    if ! run_install user; then
+        cat "$TEST_OUTPUT" >&2
         fail 'install command failed'
     fi
 
-    output=$(cat "$output_file")
+    output=$(cat "$TEST_OUTPUT")
 
-    [ -x "$home/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
-    [ ! -e "$workdir/qcontrol" ] || fail 'expected no current-directory fallback'
+    [ -x "$TEST_HOME/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
+    [ ! -e "$TEST_WORKDIR/qcontrol" ] || fail 'expected no current-directory fallback'
     assert_contains "$output" 'successfully installed qcontrol test version at'
-    assert_contains "$output" "$home/.local/bin/qcontrol"
+    assert_contains "$output" "$TEST_HOME/.local/bin/qcontrol"
     assert_contains "$output" 'qcontrol help'
+
+    teardown_test
+}
+
+test_missing_user_bin_fails_before_download() {
+    setup_test
+
+    if run_install; then
+        fail 'expected install command to fail'
+    fi
+
+    output=$(cat "$TEST_OUTPUT")
+
+    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
+    assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
+    assert_contains "$output" "$TEST_HOME/.local/bin"
+    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system'
+
+    teardown_test
+}
+
+test_unwritable_user_bin_fails_before_download() {
+    setup_test
+    mkdir -p "$TEST_HOME/.local/bin"
+    chmod 555 "$TEST_HOME/.local/bin"
+
+    if run_install; then
+        chmod 755 "$TEST_HOME/.local/bin"
+        fail 'expected install command to fail'
+    fi
+
+    chmod 755 "$TEST_HOME/.local/bin"
+    output=$(cat "$TEST_OUTPUT")
+
+    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
+    assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
+    assert_contains "$output" "$TEST_HOME/.local/bin"
+    assert_contains "$output" 'is not writable'
+    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system'
+
+    teardown_test
 }
 
 test_default_scope_installs_to_user_bin
 printf 'ok - default scope installs to user bin\n'
 test_explicit_user_scope_installs_to_user_bin
 printf 'ok - explicit user scope installs to user bin\n'
+test_missing_user_bin_fails_before_download
+printf 'ok - missing user bin fails before download\n'
+test_unwritable_user_bin_fails_before_download
+printf 'ok - unwritable user bin fails before download\n'


### PR DESCRIPTION
- defaults qcontrol install to user scope at `$HOME/.local/bin/qcontrol`
- adds explicit `system` scope for `/usr/local/bin/qcontrol`
- fails before download when the target directory is missing, unwritable, or arguments are invalid
- Adds simple test script `sh tests/qcontrol-install-test.sh`