### PR TITLE
remove qcontrol install scopes

### DIFF
--- a/qcontrol/README.md
+++ b/qcontrol/README.md
@@ -3,13 +3,8 @@
 This repo hosts installation and download scripts for Qcontrol.
 
 ```sh
-# installs into $HOME/.local/bin/qcontrol
-curl -s https://get.qpoint.io/qcontrol/install | sh
-```
-
-```sh
 # installs into /usr/local/bin/qcontrol
-curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system
+curl -s https://get.qpoint.io/qcontrol/install | sudo sh
 ```
 
 ```sh
@@ -22,8 +17,7 @@ curl -s https://get.qpoint.io/qcontrol/download | sh
 You can specify a version via the `VERSION` env var:
 
 ```sh
-curl -s https://get.qpoint.io/qcontrol/install | VERSION=v0.9.10 sh
-curl -s https://get.qpoint.io/qcontrol/install | sudo VERSION=v0.9.10 sh -s -- system
+curl -s https://get.qpoint.io/qcontrol/install | sudo VERSION=v0.9.10 sh
 curl -s https://get.qpoint.io/qcontrol/download | VERSION=v0.9.10 sh
 ```
 

--- a/qcontrol/install
+++ b/qcontrol/install
@@ -21,11 +21,7 @@
 #
 # This is an installation script for Qcontrol (https://qpoint.io). Please run:
 #
-#     curl -s https://get.qpoint.io/qcontrol/install | sh
-#
-# For a system-wide installation, run:
-#
-#     curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system
+#     curl -s https://get.qpoint.io/qcontrol/install | sudo sh
 #
 #
 
@@ -38,7 +34,6 @@ VERSION=${VERSION:-latest}
 OS=
 ARCH=
 INSTALL_PATH=
-SCOPE=
 
 RED=
 GREEN=
@@ -84,28 +79,16 @@ download_url() {
 }
 
 parse_args() {
-    if [ "$#" -gt 1 ]; then
-        usage_error "too many arguments"
+    if [ "$#" -gt 0 ]; then
+        usage_error "this script does not accept arguments"
     fi
-
-    SCOPE=${1:-user}
-
-    case "$SCOPE" in
-    user | system)
-        ;;
-    *)
-        usage_error "unsupported install scope $(bold "$SCOPE")"
-        ;;
-    esac
 }
 
 usage_error() {
     error "$*"
     printf >&2 '\n'
     printf >&2 'usage:\n\n'
-    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sh\n'
-    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system\n\n'
-    printf >&2 'accepted scopes: user, system\n'
+    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sudo sh\n'
     exit 1
 }
 
@@ -114,18 +97,14 @@ resolve_install_path() {
 }
 
 install_dir() {
-    if [ "$SCOPE" = "user" ]; then
-        printf '%s' "$HOME/.local/bin"
-    else
-        printf '%s' "${QCONTROL_TEST_SYSTEM_BIN:-/usr/local/bin}"
-    fi
+    printf '%s' "${QCONTROL_TEST_SYSTEM_BIN:-/usr/local/bin}"
 }
 
 install_target_error() {
     error "$*"
     printf >&2 '\n'
     printf >&2 'run the system install with sudo:\n\n'
-    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system\n\n'
+    printf >&2 '    curl -s https://get.qpoint.io/qcontrol/install | sudo sh\n\n'
     exit 1
 }
 

--- a/tests/qcontrol-install-test.sh
+++ b/tests/qcontrol-install-test.sh
@@ -122,90 +122,11 @@ run_install() {
     )
 }
 
-test_default_scope_installs_to_user_bin() {
-    setup_test
-    mkdir -p "$TEST_HOME/.local/bin"
-
-    if ! run_install; then
-        cat "$TEST_OUTPUT" >&2
-        fail 'install command failed'
-    fi
-
-    output=$(cat "$TEST_OUTPUT")
-
-    [ -x "$TEST_HOME/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
-    [ ! -e "$TEST_WORKDIR/qcontrol" ] || fail 'expected no current-directory fallback'
-    assert_contains "$output" 'successfully installed qcontrol test version at'
-    assert_contains "$output" "$TEST_HOME/.local/bin/qcontrol"
-    assert_contains "$output" 'qcontrol help'
-
-    teardown_test
-}
-
-test_explicit_user_scope_installs_to_user_bin() {
-    setup_test
-    mkdir -p "$TEST_HOME/.local/bin"
-
-    if ! run_install user; then
-        cat "$TEST_OUTPUT" >&2
-        fail 'install command failed'
-    fi
-
-    output=$(cat "$TEST_OUTPUT")
-
-    [ -x "$TEST_HOME/.local/bin/qcontrol" ] || fail 'expected qcontrol in user bin'
-    [ ! -e "$TEST_WORKDIR/qcontrol" ] || fail 'expected no current-directory fallback'
-    assert_contains "$output" 'successfully installed qcontrol test version at'
-    assert_contains "$output" "$TEST_HOME/.local/bin/qcontrol"
-    assert_contains "$output" 'qcontrol help'
-
-    teardown_test
-}
-
-test_missing_user_bin_fails_before_download() {
-    setup_test
-
-    if run_install; then
-        fail 'expected install command to fail'
-    fi
-
-    output=$(cat "$TEST_OUTPUT")
-
-    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
-    assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
-    assert_contains "$output" "$TEST_HOME/.local/bin"
-    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system'
-
-    teardown_test
-}
-
-test_unwritable_user_bin_fails_before_download() {
-    setup_test
-    mkdir -p "$TEST_HOME/.local/bin"
-    chmod 555 "$TEST_HOME/.local/bin"
-
-    if run_install; then
-        chmod 755 "$TEST_HOME/.local/bin"
-        fail 'expected install command to fail'
-    fi
-
-    chmod 755 "$TEST_HOME/.local/bin"
-    output=$(cat "$TEST_OUTPUT")
-
-    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
-    assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
-    assert_contains "$output" "$TEST_HOME/.local/bin"
-    assert_contains "$output" 'is not writable'
-    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system'
-
-    teardown_test
-}
-
-test_system_scope_installs_to_system_bin() {
+test_default_installs_to_system_bin() {
     setup_test
     mkdir -p "$TEST_SYSTEM_BIN"
 
-    if ! run_install system; then
+    if ! run_install; then
         cat "$TEST_OUTPUT" >&2
         fail 'install command failed'
     fi
@@ -224,7 +145,7 @@ test_system_scope_installs_to_system_bin() {
 test_missing_system_bin_fails_before_download() {
     setup_test
 
-    if run_install system; then
+    if run_install; then
         fail 'expected install command to fail'
     fi
 
@@ -233,50 +154,54 @@ test_missing_system_bin_fails_before_download() {
     assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
     assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
     assert_contains "$output" "$TEST_SYSTEM_BIN"
-    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh -s -- system'
+    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh'
 
     teardown_test
 }
 
-test_invalid_scope_fails_before_download() {
+test_unwritable_system_bin_fails_before_download() {
     setup_test
-    mkdir -p "$TEST_HOME/.local/bin" "$TEST_SYSTEM_BIN"
+    mkdir -p "$TEST_SYSTEM_BIN"
+    chmod 555 "$TEST_SYSTEM_BIN"
 
-    if run_install banana; then
+    if run_install; then
+        chmod 755 "$TEST_SYSTEM_BIN"
+        fail 'expected install command to fail'
+    fi
+
+    chmod 755 "$TEST_SYSTEM_BIN"
+    output=$(cat "$TEST_OUTPUT")
+
+    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
+    assert_not_exists "$TEST_WORKDIR/qcontrol" 'expected no current-directory fallback'
+    assert_contains "$output" "$TEST_SYSTEM_BIN"
+    assert_contains "$output" 'is not writable'
+    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh'
+
+    teardown_test
+}
+
+test_argument_fails_before_download() {
+    setup_test
+    mkdir -p "$TEST_SYSTEM_BIN"
+
+    if run_install system; then
         fail 'expected install command to fail'
     fi
 
     output=$(cat "$TEST_OUTPUT")
 
     assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
-    assert_not_exists "$TEST_HOME/.local/bin/qcontrol" 'expected no user install'
     assert_not_exists "$TEST_SYSTEM_BIN/qcontrol" 'expected no system install'
-    assert_contains "$output" 'accepted scopes: user, system'
-
-    teardown_test
-}
-
-test_extra_argument_fails_before_download() {
-    setup_test
-    mkdir -p "$TEST_HOME/.local/bin" "$TEST_SYSTEM_BIN"
-
-    if run_install user extra; then
-        fail 'expected install command to fail'
-    fi
-
-    output=$(cat "$TEST_OUTPUT")
-
-    assert_not_exists "$TEST_SANDBOX/curl-called" 'expected no download attempt'
-    assert_not_exists "$TEST_HOME/.local/bin/qcontrol" 'expected no user install'
-    assert_not_exists "$TEST_SYSTEM_BIN/qcontrol" 'expected no system install'
-    assert_contains "$output" 'accepted scopes: user, system'
+    assert_contains "$output" 'this script does not accept arguments'
+    assert_contains "$output" 'curl -s https://get.qpoint.io/qcontrol/install | sudo sh'
 
     teardown_test
 }
 
 test_version_env_is_used_in_download_url() {
     setup_test
-    mkdir -p "$TEST_HOME/.local/bin"
+    mkdir -p "$TEST_SYSTEM_BIN"
 
     VERSION=v0.9.10
     export VERSION
@@ -294,21 +219,13 @@ test_version_env_is_used_in_download_url() {
     teardown_test
 }
 
-test_default_scope_installs_to_user_bin
-printf 'ok - default scope installs to user bin\n'
-test_explicit_user_scope_installs_to_user_bin
-printf 'ok - explicit user scope installs to user bin\n'
-test_missing_user_bin_fails_before_download
-printf 'ok - missing user bin fails before download\n'
-test_unwritable_user_bin_fails_before_download
-printf 'ok - unwritable user bin fails before download\n'
-test_system_scope_installs_to_system_bin
-printf 'ok - system scope installs to system bin\n'
+test_default_installs_to_system_bin
+printf 'ok - default installs to system bin\n'
 test_missing_system_bin_fails_before_download
 printf 'ok - missing system bin fails before download\n'
-test_invalid_scope_fails_before_download
-printf 'ok - invalid scope fails before download\n'
-test_extra_argument_fails_before_download
-printf 'ok - extra argument fails before download\n'
+test_unwritable_system_bin_fails_before_download
+printf 'ok - unwritable system bin fails before download\n'
+test_argument_fails_before_download
+printf 'ok - argument fails before download\n'
 test_version_env_is_used_in_download_url
 printf 'ok - version env is used in download url\n'


### PR DESCRIPTION
## Summary
- removes the qcontrol install scope argument entirely
- defaults the install target back to `/usr/local/bin/qcontrol`
- fails before download when the system install directory is missing, unwritable, or arguments are provided

## Tests
- `sh tests/qcontrol-install-test.sh`
- `sh -n qcontrol/install && sh -n tests/qcontrol-install-test.sh`
- `git diff --check`
- `shellcheck qcontrol/install tests/qcontrol-install-test.sh` could not run because `shellcheck` is not installed

## Notes
- keeps current-directory installs in the separate qcontrol download workflow
- excludes the untracked plan files from this PR