### PR TITLE
Add qcontrol download & install page

### DIFF
--- a/qcontrol/index.html
+++ b/qcontrol/index.html
@@ -1,0 +1,380 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Download qcontrol · Qpoint</title>
+<meta name="description" content="Install qcontrol — a single binary for macOS, Linux, or Windows." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* ---- tokens pulled from www.qpoint.io tailwind/styleguide layer ---- */
+  :root {
+    --grape:      #895AE8;  /* grape / grape-500 */
+    --grape-600:  #7742E2;
+    --grape-500:  #895AE8;
+    --grape-400:  #AB86F6;
+    --grape-200:  #D7CAFE;
+    --grape-100:  #EFEBFC;
+    --grape-50:   #F9F7FF;
+    --grey-900:   #111111;
+    --grey-700:   #3a3a3a;
+    --grey-600:   #565454;
+    --grey-400:   #9E9E9E;
+    --grey-300:   #D4D4D4;
+    --grey-200:   #E8E8E8;
+    --grey-100:   #F5F5F5;
+    --white:      #ffffff;
+    --sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    --mono: 'Consolas', 'Monaco', 'Andale Mono', 'Ubuntu Mono', monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background: var(--white);
+    color: var(--grey-600);
+    font-family: var(--sans);
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--grape-500); text-decoration: none; }
+  a:hover { color: var(--grey-900); }
+
+  .page { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
+  @media (min-width: 1024px) { .page { padding: 0 48px; } }
+
+  /* ---- nav ---- */
+  nav { border-bottom: 1px solid var(--grey-200); }
+  nav .page { display: flex; align-items: center; justify-content: space-between; height: 68px; }
+  .brand { display: flex; align-items: center; gap: 9px; font-weight: 700; color: var(--grey-900); font-size: 18px; }
+  .brand .dot { width: 11px; height: 11px; border-radius: 50%; background: var(--grape-500); }
+  nav .links { display: flex; gap: 26px; font-size: 15px; }
+  nav .links a { color: var(--grey-600); }
+  nav .links a:hover { color: var(--grey-900); }
+
+  /* ---- hero ---- */
+  .hero { padding: 64px 0 8px; }
+  .eyebrow { color: var(--grape); font-weight: 600; font-size: 20px; margin-bottom: 6px; }
+  h1 { color: var(--grey-900); font-weight: 700; letter-spacing: -0.02em; line-height: 1.08;
+       font-size: clamp(38px, 6vw, 58px); margin: 0 0 16px; }
+  .lede { font-size: 18px; color: var(--grey-600); max-width: 620px; margin: 0; }
+
+  /* ---- detected primary download ---- */
+  .cta-card {
+    margin: 40px 0 8px; padding: 24px;
+    background: linear-gradient(135deg, var(--grape-50), var(--grape-100));
+    border: 1px solid var(--grape-200); border-radius: 14px;
+  }
+  .cta-card .row { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 16px; }
+  .detected { font-size: 15px; color: var(--grey-600); }
+  .detected strong { color: var(--grey-900); font-weight: 600; }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px; height: 56px; padding: 0 32px;
+    border-radius: 8px; border: 0; cursor: pointer; font-family: var(--sans);
+    font-size: 18px; font-weight: 600; background: var(--grape-600); color: #fff;
+    transition: background .2s ease;
+  }
+  .btn:hover { background: var(--grape-500); color: #fff; }
+  .btn svg { width: 18px; height: 18px; }
+  .alt-link { font-size: 14px; color: var(--grey-600); margin-top: 14px; }
+
+  /* ---- section headings ---- */
+  h2.section { color: var(--grey-900); font-weight: 700; font-size: 28px; margin: 64px 0 8px; letter-spacing: -0.01em; }
+  .section-sub { color: var(--grey-600); font-size: 16px; margin: 0 0 24px; }
+
+  /* ---- platform cards ---- */
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; }
+  .card { background: var(--white); border: 1px solid var(--grey-200); border-radius: 12px; padding: 24px;
+          box-shadow: 0 1px 2px rgba(17,17,17,.04); transition: box-shadow .2s ease, border-color .2s ease; }
+  .card:hover { box-shadow: 0 12px 28px rgba(119,66,226,.10); border-color: var(--grape-200); }
+  .card h3 { color: var(--grey-900); font-weight: 700; font-size: 18px; margin: 0 0 2px; display: flex; align-items: center; gap: 8px; }
+  .card .arch { color: var(--grey-400); font-size: 14px; margin: 0 0 18px; }
+  .card .links { display: flex; flex-direction: column; gap: 10px; }
+  .card .links a { font-family: var(--mono); font-size: 14px; color: var(--grape-600); font-weight: 600; }
+  .card .links a:hover { color: var(--grey-900); }
+  .pill { font-family: var(--sans); font-size: 11px; font-weight: 600; color: var(--grape-600);
+          background: var(--grape-100); border-radius: 999px; padding: 2px 9px; }
+  .pill.soon { color: var(--grey-400); background: var(--grey-100); }
+
+  /* coming-soon platform cards */
+  .card.soon { background: var(--grey-100); border-style: dashed; box-shadow: none; }
+  .card.soon:hover { box-shadow: none; border-color: var(--grey-300); }
+  .card.soon h3 { color: var(--grey-400); }
+  .card.soon .msg { color: var(--grey-400); font-size: 14px; margin: 0; }
+
+  .btn.disabled { background: var(--grey-200); color: var(--grey-400); pointer-events: none; }
+
+  /* ---- install: tabs + copyable command panels ---- */
+  .tabs { display: flex; gap: 8px; margin: 0 0 18px; flex-wrap: wrap; }
+  .tab { font-family: var(--sans); font-size: 15px; padding: 8px 18px; border-radius: 999px; cursor: pointer;
+         background: var(--white); border: 1px solid var(--grey-300); color: var(--grey-600); }
+  .tab[aria-selected="true"] { background: var(--grape-500); border-color: var(--grape-500); color: #fff; }
+  .panel { display: none; }
+  .panel.active { display: block; }
+  .step { color: var(--grey-600); font-size: 15px; margin: 0 0 10px; }
+  .step code, p code { font-family: var(--mono); font-size: 13.5px; color: var(--grape-600); background: var(--grape-50); padding: 1px 6px; border-radius: 5px; }
+
+  .codeblock { background: var(--grey-200); border-radius: 14px; overflow: hidden; margin: 0 0 20px; max-width: 720px; }
+  .codeblock .title { font-family: var(--mono); font-size: 13px; font-weight: 700; color: var(--grape); padding: 10px 20px 2px; }
+  .cmd { display: flex; align-items: center; justify-content: space-between; gap: 16px; cursor: pointer;
+         font-family: var(--mono); font-size: 13.5px; font-weight: 700; color: var(--grape-600);
+         padding: 7px 20px; transition: color .15s ease; }
+  .cmd:last-child { padding-bottom: 16px; }
+  .cmd:hover { color: var(--grey-900); }
+  .cmd .txt { white-space: pre-wrap; word-break: break-all; }
+  .cmd .copy { font-family: var(--sans); font-size: 11px; color: var(--grey-400); display: flex; align-items: center; gap: 4px; flex: none; }
+  .cmd:hover .copy { color: var(--grape-600); }
+  .cmd.copied .copy { color: var(--grape-600); }
+
+  .note { border-left: 3px solid var(--grape-400); background: var(--grape-50); padding: 14px 18px;
+          border-radius: 0 10px 10px 0; font-size: 14.5px; color: var(--grey-700); margin: 18px 0; max-width: 720px; }
+  .note b { color: var(--grape-600); }
+  .note code { font-family: var(--mono); font-size: 13px; color: var(--grape-600); }
+
+  /* ---- numbered getting-started steps ---- */
+  .steps { display: flex; flex-direction: column; gap: 8px; }
+  .step-item { display: grid; grid-template-columns: 44px 1fr; gap: 20px; padding: 8px 0 28px; position: relative; }
+  .step-item:not(:last-child)::before { content: ""; position: absolute; left: 21px; top: 52px; bottom: 0; width: 2px; background: var(--grape-100); }
+  .step-num { width: 44px; height: 44px; border-radius: 50%; background: var(--grape-600); color: #fff;
+              display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 18px; z-index: 1; }
+  .step-body h3 { color: var(--grey-900); font-weight: 700; font-size: 19px; margin: 8px 0 6px; }
+  .step-body > p { color: var(--grey-600); font-size: 15px; margin: 0 0 14px; max-width: 640px; }
+  .step-body .codeblock { margin-top: 4px; }
+  .kbd { font-family: var(--mono); font-size: 12.5px; color: var(--grape-600); background: var(--grape-100); padding: 1px 7px; border-radius: 5px; font-weight: 600; }
+
+  /* ---- tray-first layout: menu mock + feature list ---- */
+  .tray-split { display: grid; grid-template-columns: 1.05fr 1fr; gap: 40px; align-items: start; margin-top: 24px; }
+  @media (max-width: 860px) { .tray-split { grid-template-columns: 1fr; gap: 28px; } }
+
+  /* macOS menu-bar dropdown mock */
+  .menubar { background: linear-gradient(180deg, #fafafa, #f0f0f0); border: 1px solid var(--grey-300);
+             border-radius: 8px 8px 0 0; padding: 6px 12px; display: flex; align-items: center; gap: 8px;
+             font-size: 13px; color: var(--grey-600); }
+  .menubar .glyph { color: var(--grape-600); font-weight: 700; }
+  .menubar .spacer { flex: 1; }
+  .tray-menu { background: var(--white); border: 1px solid var(--grey-300); border-top: 0;
+               border-radius: 0 0 12px 12px; box-shadow: 0 20px 45px rgba(17,17,17,.14); overflow: hidden;
+               font-size: 13.5px; }
+  .tray-menu .mi { padding: 7px 14px; display: flex; align-items: center; gap: 8px; color: var(--grey-700); }
+  .tray-menu .mi.head { color: var(--grey-400); font-size: 12px; font-weight: 600; text-transform: none; padding-top: 9px; }
+  .tray-menu .mi.title { color: var(--grey-900); font-weight: 700; background: var(--grape-50); }
+  .tray-menu .mi.agent { justify-content: flex-start; }
+  .tray-menu .mi.agent .tp { margin-left: auto; color: var(--grape-600); font-weight: 600; font-size: 12.5px; }
+  .tray-menu .mi.hoverable:hover { background: var(--grape-500); color: #fff; }
+  .tray-menu .mi.hoverable:hover .tp { color: #fff; }
+  .tray-menu .ok { color: #16a34a; font-weight: 700; }
+  .tray-menu .off { color: var(--grey-400); font-weight: 700; }
+  .tray-menu .check { margin-left: auto; color: var(--grape-600); font-weight: 700; }
+  .tray-menu .sep { height: 1px; background: var(--grey-200); margin: 4px 0; }
+  .tray-menu .mi.strong { color: var(--grey-900); font-weight: 600; }
+  .menu-caption { font-size: 12.5px; color: var(--grey-400); text-align: center; margin-top: 10px; }
+
+  /* deployment hint: how a fleet / IT admin runs the same thing */
+  .mdm-note { font-size: 13.5px; color: var(--grey-400); margin: 14px 0 0; padding-left: 12px; border-left: 2px solid var(--grape-200); }
+  .mdm-note b { color: var(--grape-600); }
+  .mdm-note code { font-family: var(--mono); font-size: 12.5px; color: var(--grape-600); background: var(--grape-50); padding: 1px 6px; border-radius: 5px; }
+
+  /* what-you-can-do feature list */
+  .feat { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 18px; }
+  .feat li { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .feat .ic { width: 26px; height: 26px; border-radius: 7px; background: var(--grape-100); color: var(--grape-600);
+              display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 14px; }
+  .feat h4 { color: var(--grey-900); font-weight: 700; font-size: 15.5px; margin: 2px 0 3px; }
+  .feat p { color: var(--grey-600); font-size: 14px; margin: 0; }
+
+  footer { margin-top: 72px; border-top: 1px solid var(--grey-200); }
+  footer .page { display: flex; gap: 22px; flex-wrap: wrap; align-items: center; padding-top: 22px; padding-bottom: 40px;
+                 color: var(--grey-400); font-size: 14px; }
+  footer a { color: var(--grey-600); }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="page">
+    <a class="brand" href="https://www.qpoint.io"><span class="dot"></span> Qpoint</a>
+  </div>
+</nav>
+
+<div class="page">
+
+  <section class="hero">
+    <div class="eyebrow">Download</div>
+    <h1>Install qcontrol</h1>
+    <p class="lede">A single binary that wraps and observes every AI agent on the machine — no gateways, no SDKs. Available now for macOS; Linux and Windows are coming soon.</p>
+
+    <div class="cta-card">
+      <div class="row">
+        <div class="detected" id="detected">Detecting your platform…</div>
+        <a class="btn" id="primaryBtn" href="#downloads">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0l-4-4m4 4l4-4M4 21h16"/></svg>
+          <span id="primaryLabel">Choose your platform</span>
+        </a>
+      </div>
+      <div class="alt-link" id="altLink"></div>
+    </div>
+  </section>
+
+  <h2 class="section" id="downloads">All downloads</h2>
+  <p class="section-sub">Always resolves to the latest release.</p>
+  <div class="grid">
+    <div class="card">
+      <h3>macOS <span class="pill">Apple Silicon</span></h3>
+      <p class="arch">arm64 · M1 or newer</p>
+      <div class="links">
+        <a data-dl="macos-arm64.pkg">Installer · .pkg</a>
+        <a data-dl="macos-arm64.tgz">Tarball · .tgz</a>
+      </div>
+    </div>
+    <div class="card soon">
+      <h3>Linux <span class="pill soon">Coming soon</span></h3>
+      <p class="arch">x86_64 &amp; arm64</p>
+      <p class="msg">Native builds are on the way.</p>
+    </div>
+    <div class="card soon">
+      <h3>Windows <span class="pill soon">Coming soon</span></h3>
+      <p class="arch">x64</p>
+      <p class="msg">Native builds are on the way.</p>
+    </div>
+  </div>
+
+  <h2 class="section">Get started on macOS</h2>
+  <p class="section-sub">The menu-bar tray is the interface. Install, open it once, and everything else is a click.</p>
+
+  <div class="steps">
+    <div class="step-item">
+      <div class="step-num">1</div>
+      <div class="step-body">
+        <h3>Install the package</h3>
+        <p>Double-click the downloaded <span class="kbd">.pkg</span> — or run it from a terminal. It puts <code>qcontrol</code> on your PATH and sets up machine trust automatically. No extra setup.</p>
+        <div class="codeblock">
+          <div class="cmd"><span class="txt">sudo installer -pkg ~/Downloads/qcontrol-latest-macos-arm64.pkg -target /</span><span class="copy">copy</span></div>
+        </div>
+        <div class="note"><b>Unsigned build:</b> Gatekeeper flags it as from an unidentified developer. Install with the command above, or in Finder <b>right-click the .pkg → Open</b>.</div>
+        <p class="mdm-note">Rolling out to a fleet? Push the same <b>.pkg through MDM</b> — the installer needs no logged-in user and sets machine trust in its postinstall.</p>
+      </div>
+    </div>
+
+    <div class="step-item">
+      <div class="step-num">2</div>
+      <div class="step-body">
+        <h3>Open qcontrol</h3>
+        <p>Run this once to launch the tray. A qcontrol icon appears in your menu bar — that's your whole interface from here on.</p>
+        <div class="codeblock">
+          <div class="cmd"><span class="txt">qcontrol scan</span><span class="copy">copy</span></div>
+        </div>
+        <p class="mdm-note">To keep it monitoring in the background, or run it headless on a managed fleet, use <code>qcontrol start</code> (stop with <code>qcontrol stop</code>) — <b>or run it via MDM</b> as a launch agent.</p>
+      </div>
+    </div>
+  </div>
+
+  <h2 class="section">Everything else is in the menu bar</h2>
+  <p class="section-sub">Click the qcontrol icon — discovery is automatic, tapping is a click.</p>
+
+  <div class="tray-split">
+    <div>
+      <div class="menubar">
+        <span style="font-weight:700;color:var(--grey-900)">Finder</span><span>File</span><span>Edit</span><span>View</span>
+        <span class="spacer"></span>
+        <span class="glyph">⊘ qcontrol</span><span>🔋</span><span>Wed 9:41</span>
+      </div>
+      <div class="tray-menu">
+        <div class="mi title">qcontrol — running 2, installed 5</div>
+        <div class="mi head">Running (2)</div>
+        <div class="mi agent hoverable"><span class="ok">✓</span> claude — pid 4820<span class="tp">Untap</span></div>
+        <div class="mi agent hoverable"><span class="off">⊘</span> codex — pid 5119<span class="tp">Tap</span></div>
+        <div class="sep"></div>
+        <div class="mi head">Installed</div>
+        <div class="mi agent hoverable"><span class="ok">✓</span> claude-code&nbsp;&nbsp;v1.2<span class="tp">Untap</span></div>
+        <div class="mi agent hoverable"><span class="off">⊘</span> cursor&nbsp;&nbsp;v0.44<span class="tp">Tap</span></div>
+        <div class="mi agent hoverable"><span class="off">⊘</span> gemini-cli<span class="tp">Tap</span></div>
+        <div class="sep"></div>
+        <div class="mi strong hoverable">Auto-tap new agents<span class="check">✓</span></div>
+        <div class="mi strong hoverable">Tap all (admin)…</div>
+        <div class="mi hoverable">Untap all (admin)…</div>
+        <div class="sep"></div>
+        <div class="mi hoverable">Rescan installations</div>
+        <div class="mi hoverable">Quit</div>
+      </div>
+      <div class="menu-caption">The actual qcontrol menu: live counts, per-agent tap toggles, and bulk actions.</div>
+    </div>
+
+    <ul class="feat">
+      <li><div class="ic">◎</div><div><h4>See every agent</h4><p>The header counts what's running and installed. Each entry shows <span class="ok" style="color:#16a34a">✓</span> tapped or <span class="off">⊘</span> untapped.</p></div></li>
+      <li><div class="ic">⚡</div><div><h4>Auto-tap new agents</h4><p>Flip it on and qcontrol taps every newly discovered, user-writable agent the moment it appears — no prompts.</p></div></li>
+      <li><div class="ic">✓</div><div><h4>Tap all in one click</h4><p><b>Tap all (admin)…</b> sweeps everything behind a single admin prompt — including protected apps under Homebrew and <code>/Applications</code>.</p></div></li>
+      <li><div class="ic">↺</div><div><h4>Toggle anything</h4><p>Click any agent to tap or untap it individually. Rescan refreshes discovery on demand.</p></div></li>
+    </ul>
+  </div>
+
+</div>
+
+<footer>
+  <div class="page">
+    <a href="https://www.qpoint.io">qpoint.io</a>
+    <span>© Qpoint</span>
+  </div>
+</footer>
+
+<script>
+  // ---------------------------------------------------------------------------
+  // Single knob: the public base URL the release artifacts are served from.
+  // Binaries live in the Cloudflare R2 `downloads` bucket under `qcontrol/`.
+  // Point this at whatever public domain the team wires up. No trailing slash.
+  // ---------------------------------------------------------------------------
+  const DOWNLOAD_BASE = "https://downloads.qpoint.io";
+  const url = (suffix) => `${DOWNLOAD_BASE}/qcontrol/qcontrol-latest-${suffix}`;
+
+  // Wire every download link to its real artifact URL.
+  document.querySelectorAll("[data-dl]").forEach((a) => { a.href = url(a.getAttribute("data-dl")); });
+
+  // ---- platform detection for the primary button ----
+  // Only macOS ships today; Linux and Windows are coming soon, so a non-mac
+  // visitor gets a disabled "coming soon" button plus the available macOS build.
+  function detect() {
+    const ua = navigator.userAgent, plat = (navigator.platform || "").toLowerCase();
+    if (/mac/i.test(ua) || plat.includes("mac")) return "macos";
+    if (/win/i.test(ua) || plat.includes("win")) return "windows";
+    if (/linux|x11/i.test(ua) || plat.includes("linux")) return "linux";
+    return null;
+  }
+
+  const os = detect();
+  const detectedEl = document.getElementById("detected");
+  const btn = document.getElementById("primaryBtn");
+  const labelEl = document.getElementById("primaryLabel");
+  const altEl = document.getElementById("altLink");
+
+  if (os === "macos") {
+    detectedEl.innerHTML = `Detected <strong>macOS</strong>`;
+    btn.href = url("macos-arm64.pkg");
+    labelEl.textContent = "Download for macOS";
+    altEl.textContent = "Apple Silicon (M1 or newer).";
+  } else if (os === "linux" || os === "windows") {
+    const name = os === "linux" ? "Linux" : "Windows";
+    detectedEl.innerHTML = `Detected <strong>${name}</strong> — support is coming soon`;
+    btn.classList.add("disabled");
+    labelEl.textContent = "Coming soon";
+    altEl.innerHTML = 'macOS is available today — <a href="' + url("macos-arm64.pkg") + '">download the macOS build</a>.';
+  } else {
+    detectedEl.textContent = "macOS available now — Linux and Windows coming soon.";
+    btn.href = url("macos-arm64.pkg");
+    labelEl.textContent = "Download for macOS";
+  }
+
+  // ---- click-to-copy command lines (mirrors the site's SingleLineCopy) ----
+  document.querySelectorAll(".cmd").forEach((row) => {
+    row.addEventListener("click", async () => {
+      const text = row.querySelector(".txt").textContent;
+      try { await navigator.clipboard.writeText(text); }
+      catch { const ta = document.createElement("textarea"); ta.value = text; ta.style.position = "fixed"; ta.style.opacity = "0";
+              document.body.appendChild(ta); ta.select(); document.execCommand("copy"); document.body.removeChild(ta); }
+      const label = row.querySelector(".copy");
+      row.classList.add("copied"); label.textContent = "copied";
+      setTimeout(() => { row.classList.remove("copied"); label.textContent = "copy"; }, 2000);
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a standalone, self-contained download/install landing page for **qcontrol** at `qcontrol/index.html`, served at `https://get.qpoint.io/qcontrol/`.

Since Jekyll serves `index.html` in preference to `README.md`, this replaces the bare README index at `/qcontrol/`. The existing `qcontrol/install` and `qcontrol/download` scripts are untouched, and `README.md` stays for the GitHub repo view.

## Design

- Matches the **www.qpoint.io** design system (grape/grey tokens, Inter, `.eyebrow`, `card-marketing`, click-to-copy command lines) — colors and patterns pulled from the site's compiled CSS and components, not guessed.
- Single self-contained file: inline CSS/JS, no build step, only external dep is Inter from Google Fonts (system fallback offline).

## Content

- **macOS is the featured platform** (the only shipping build). Tray-first getting-started flow: install `.pkg` → `qcontrol scan` opens the menu-bar tray → everything else (discovery, tapping, status) is a click. Includes a faithful mock of the real qtray menu.
- **MDM notes** on the background/`start` path for fleet rollout.
- **Linux & Windows** are marked **Coming soon** (cards + detected-OS CTA).
- OS auto-detection picks the primary button; non-mac visitors get a "Coming soon" state plus the available macOS build.

## Wiring

- Downloads point at `https://downloads.qpoint.io/qcontrol/qcontrol-latest-<os>-<arch>.{pkg,tgz}` (verified live, 200) via a single `DOWNLOAD_BASE` constant.

## Verify locally

```sh
python3 -m http.server   # from repo root
open http://localhost:8000/qcontrol/
```